### PR TITLE
Guard staticContext on the client side App.js

### DIFF
--- a/src/shared/components/App/App.js
+++ b/src/shared/components/App/App.js
@@ -24,10 +24,13 @@ function App() {
       </Helmet>
       <Layout>
         <Switch>
-          {routes.map(route => (
+          {routes.map(({ component: Component, ...route }) =>
             // pass in the initialData from the server for this specific route
-            <Route {...route} key={uuid.v4()} />
-          ))}
+            // there is no `staticContext` on the client, so
+            // we need to guard against that here
+            <Route {...route} key={uuid.v4()} component={({ staticContext, ...props }) =>
+              <Component {...props} />} />
+          )}
           <Route component={NotFound} />
         </Switch>
       </Layout>


### PR DESCRIPTION
As we are dealing with server-side rendering, we need to check if staticContext exists on the client side, to avoid the following error: 

<img width="1549" alt="screen shot 2017-10-08 at 22 25 27" src="https://user-images.githubusercontent.com/9677898/31320795-da02293a-ac7a-11e7-8984-b2d29669fbbb.png">
