### PR TITLE
Allow to specify fetchData fn in the route object

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -34,11 +34,12 @@ export default ({ clientStats }) => {
     const matches = routes.reduce((matches, route) => {
       const match = matchPath(req.url, route.path, route);
       if (match && match.isExact) {
+        const fetchData = route.component.fetchData || route.fetchData;
         matches.push({
           route,
           match,
-          promise: route.component.fetchData
-            ? route.component.fetchData({ store, params: match.params })
+          promise: fetchData
+            ? fetchData({ store, params: match.params })
             : Promise.resolve(),
         });
       }


### PR DESCRIPTION
Like this:

```
{
    path: '/countries/:page?',
    exact: true,
    component: Countries,
    fetchData({ store, params }) {
      return store.dispatch(fetchContent(params.page || '1', 'countries'));
    },
  },
```

I had issues that too many HOC and static function was disappearing it couldn't find it. So I just added it here which is also nice.