### PR TITLE
Add babel-plugin-transform for spread transformations support

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "babel-plugin-styled-components": "^1.2.1",
     "babel-plugin-syntax-dynamic-import": "^7.0.0-beta.2",
     "babel-plugin-transform-class-properties": "^7.0.0-beta.2",
+    "babel-plugin-transform-es2015-spread": "^7.0.0-beta.2",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^7.0.0-beta.2",
     "babel-plugin-transform-react-constant-elements": "7.0.0-beta.2",

--- a/tools/webpack/createWebpackConfig.js
+++ b/tools/webpack/createWebpackConfig.js
@@ -458,6 +458,9 @@ export default function createWebpackConfig(options) {
                     loose: true,
                   },
                 ],
+                // [...a, 'foo'];
+                // @see https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-es2015-spread
+                'transform-es2015-spread',
                 // ...foo
                 // @see: https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-rest-spread
                 [

--- a/yarn.lock
+++ b/yarn.lock
@@ -983,7 +983,7 @@ babel-plugin-transform-es2015-shorthand-properties@7.0.0-beta.2:
   dependencies:
     babel-types "7.0.0-beta.2"
 
-babel-plugin-transform-es2015-spread@7.0.0-beta.2:
+babel-plugin-transform-es2015-spread@7.0.0-beta.2, babel-plugin-transform-es2015-spread@^7.0.0-beta.2:
   version "7.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-7.0.0-beta.2.tgz#c166da155f2edf8d23d6b6c53056740bce95f83d"
 


### PR DESCRIPTION
added the preset to support transformations, for example the following stateless function wouldn't work without the preset.

```
const Hello = () => <div>{[...Array(6)].map((_, i) => <h1 key={i}>Phantom</h1>)}</div>;
```